### PR TITLE
Fix typo in array notation

### DIFF
--- a/rust/basics/README.md
+++ b/rust/basics/README.md
@@ -22,7 +22,7 @@ let float_64: f64;
 
 // Arrays
 // Fixed size
-let bytes: [u8; [32]];
+let bytes: [u8; 42];
 // Variable size
 let byte_vec: Vec<u8>;
 


### PR DESCRIPTION
Fix the array notation of the basics section, according to https://doc.rust-lang.org/reference/types/array.html. Also in https://stackoverflow.com/a/58733086 the maximum size is given, there is no limit of `32` elements in an array. :wink:

Thanks for the great training session!

P.S.: Also added a missing newline at EOF. :sunglasses: 